### PR TITLE
Add classifications to the response

### DIFF
--- a/LabeledByAI.Services.Tests/Services/Engagement/CalculateScoreAsync_Issue.cs
+++ b/LabeledByAI.Services.Tests/Services/Engagement/CalculateScoreAsync_Issue.cs
@@ -37,7 +37,8 @@ public partial class EngagementServiceUnitTests
                 expectedIssue.Number);
             var expectedResponseEngagement = new EngagementResponseEngagement(
                 Score: 11, 
-                PreviousScore: 5);
+                PreviousScore: 5,
+                EngagementResponseEngagementClassification.Hot);
 
             var response = await service.CalculateScoreAsync(
                 new EngagementRequestIssue(TestOwner, TestRepo, 1),

--- a/LabeledByAI.Services/Services/Engagement/EngagementResponseEngagement.cs
+++ b/LabeledByAI.Services/Services/Engagement/EngagementResponseEngagement.cs
@@ -2,4 +2,5 @@
 
 public record EngagementResponseEngagement(
     int Score,
-    int PreviousScore);
+    int PreviousScore,
+    EngagementResponseEngagementClassification? Classification);

--- a/LabeledByAI.Services/Services/Engagement/EngagementResponseEngagementClassification.cs
+++ b/LabeledByAI.Services/Services/Engagement/EngagementResponseEngagementClassification.cs
@@ -1,0 +1,6 @@
+﻿namespace LabeledByAI.Services;
+
+public enum EngagementResponseEngagementClassification
+{
+    Hot,
+}

--- a/LabeledByAI.Services/Services/Engagement/EngagementService.cs
+++ b/LabeledByAI.Services/Services/Engagement/EngagementService.cs
@@ -90,7 +90,10 @@ public class EngagementService(IGitHubConnection githubConnection, ILogger<Engag
                     issue.Number),
                 new EngagementResponseEngagement(
                     score,
-                    previousScore));
+                    previousScore,
+                    score > previousScore
+                        ? EngagementResponseEngagementClassification.Hot
+                        : null));
 
             items.Add(item);
         }
@@ -155,7 +158,10 @@ public class EngagementService(IGitHubConnection githubConnection, ILogger<Engag
                 content,
                 new EngagementResponseEngagement(
                     score,
-                    previousScore));
+                    previousScore,
+                    score > previousScore
+                        ? EngagementResponseEngagementClassification.Hot
+                        : null));
 
             items.Add(item);
         }

--- a/LabeledByAI.Services/Services/JsonExtensions.cs
+++ b/LabeledByAI.Services/Services/JsonExtensions.cs
@@ -24,5 +24,10 @@ public static class JsonExtensions
             IgnoreReadOnlyProperties = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters =
+            {
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+            }
         };
 }

--- a/LabeledByAI/Functions/EngagementScoreFunction.cs
+++ b/LabeledByAI/Functions/EngagementScoreFunction.cs
@@ -16,6 +16,6 @@ public class EngagementScoreFunction(GitHubRemoteConnection connection, Engageme
     {
         connection.SetToken(request.GetGithubToken());
         var response = await service.CalculateScoresAsync(parsedBody);
-        return TypedResults.Ok(response);
+        return TypedResults.Json(response, JsonExtensions.SerializerOptions);
     }
 }

--- a/LabeledByAI/Functions/LabelSelectorFunction.cs
+++ b/LabeledByAI/Functions/LabelSelectorFunction.cs
@@ -16,6 +16,6 @@ public class LabelSelectorFunction(GitHubRemoteConnection connection, LabelSelec
     {
         connection.SetToken(request.GetGithubToken());
         var response = await service.SelectLabelAsync(parsedBody);
-        return TypedResults.Ok(response);
+        return TypedResults.Json(response, JsonExtensions.SerializerOptions);
     }
 }


### PR DESCRIPTION
This PR adds a "classification" to each issue so they can easily be updated with labels or values in projects.

This PR specifically adds a "hot" classification if the issue appears to be suddenly trending.